### PR TITLE
Use jelly markup

### DIFF
--- a/src/main/resources/net/praqma/jenkins/configrotator/scm/clearcaseucm/ClearCaseUCMTarget/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/configrotator/scm/clearcaseucm/ClearCaseUCMTarget/config.jelly
@@ -1,22 +1,13 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <tr>
-        <td>
-            Baseline
-            <f:textbox field="baselineName"/>
-        </td>
-        <td>
-            Promotion level
-            <f:select field="level"/>
-        </td>
-        <td>
-            <tr>
-                <td>
-                    Fixed
-                    <f:checkbox field="fixed"/>
-                </td>
-            </tr>
-        </td>
-    </tr>
+    <f:entry title="Baseline">
+        <f:textbox field="baselineName"/>
+    </f:entry>
+    <f:entry title="Promotion level">
+        <f:select field="level"/>
+    </f:entry>
+    <f:entry>
+        <f:checkbox field="fixed" title="Fixed"/>
+    </f:entry>
     <f:repeatableDeleteButton/>
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/configrotator/scm/git/GitTarget/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/configrotator/scm/git/GitTarget/config.jelly
@@ -1,29 +1,19 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <tr>
-        <td>
-            Name <f:textbox field="name"/>
-        </td>
-        <td>
-            Branch
-            <f:textbox field="branch"/>
-        </td>
-        <td>
-            Repository
-            <f:textbox field="repository"/>
-        </td>
-        <td>
-            Commit
-            <f:textbox field="commitId"/>
-        </td>
-        <td>
-            <tr>
-                <td>
-                    Fixed
-                    <f:checkbox field="fixed"/>
-                </td>
-            </tr>
-        </td>
-    </tr>
+    <f:entry title="Name">
+        <f:textbox field="name"/>
+    </f:entry>
+    <f:entry title="Branch">
+        <f:textbox field="branch"/>
+    </f:entry>
+    <f:entry title="Repository">
+        <f:textbox field="repository"/>
+    </f:entry>
+    <f:entry title="Commit">
+        <f:textbox field="commitId"/>
+    </f:entry>
+    <f:entry>
+        <f:checkbox field="fixed" title="Fixed"/>
+    </f:entry>
     <f:repeatableDeleteButton/>
 </j:jelly>


### PR DESCRIPTION
This isn't tested.

I ran into something which looked like this module while working on jenkinsci/jenkins#3895

The "styling" of `Fixed` here looked suspicious:
![image](https://user-images.githubusercontent.com/2119212/80308815-0617e300-879f-11ea-8350-b28bab4d1e7d.png)
